### PR TITLE
print variables like "name=value"

### DIFF
--- a/q.go
+++ b/q.go
@@ -138,8 +138,8 @@ func qCall(n *ast.CallExpr) bool {
 	return false
 }
 
-// argName returns the variable name of the given argument if it's a variable.
-// If the argument is something else, like a literal or a function call, argName
+// argName returns the name of the given argument if it's a variable. If the
+// argument is something else, like a literal or a function call, argName
 // returns an empty string.
 func argName(arg ast.Expr) string {
 	if ident, is := arg.(*ast.Ident); is && ident.Obj.Kind == ast.Var {

--- a/q.go
+++ b/q.go
@@ -1,7 +1,6 @@
 package q
 
 import (
-	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -108,7 +107,7 @@ func argNames(file string, line int) ([]string, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, file, nil, 0)
 	if err != nil {
-		return nil, errors.New("failed to parse source file: " + file)
+		return nil, err
 	}
 
 	var names []string

--- a/q.go
+++ b/q.go
@@ -26,17 +26,18 @@ func Println(a ...interface{}) {
 	defer fd.Close()
 
 	pc, file, line, ok := runtime.Caller(1)
-	if ok {
-		p := []interface{}{prefix(pc, file, line)}
-		a = append(p, a...)
+	if !ok {
 		mu.Lock()
 		_, err = fmt.Fprintln(fd, a...)
 		mu.Unlock()
-	} else {
-		mu.Lock()
-		_, err = fmt.Fprintln(fd, a...)
-		mu.Unlock()
+		return
 	}
+
+	p := []interface{}{prefix(pc, file, line)}
+	a = append(p, a...)
+	mu.Lock()
+	_, err = fmt.Fprintln(fd, a...)
+	mu.Unlock()
 
 	if err != nil {
 		panic(err) // TODO: don't panic
@@ -52,16 +53,17 @@ func Printf(format string, a ...interface{}) {
 	defer fd.Close()
 
 	pc, file, line, ok := runtime.Caller(1)
-	if ok {
-		p := prefix(pc, file, line)
-		mu.Lock()
-		_, err = fmt.Fprintf(fd, p+" "+format, a...)
-		mu.Unlock()
-	} else {
+	if !ok {
 		mu.Lock()
 		_, err = fmt.Fprintf(fd, format, a...)
 		mu.Unlock()
+		return
 	}
+
+	p := prefix(pc, file, line)
+	mu.Lock()
+	_, err = fmt.Fprintf(fd, p+" "+format, a...)
+	mu.Unlock()
 
 	if err != nil {
 		panic(err) // TODO: don't panic

--- a/q.go
+++ b/q.go
@@ -30,20 +30,16 @@ func Println(a ...interface{}) {
 	defer fd.Close()
 
 	pc, file, line, ok := runtime.Caller(1)
-	if !ok {
-		mu.Lock()
-		_, err = fmt.Fprintln(fd, a...)
-		mu.Unlock()
-		return
+	if ok {
+		argNames, err := argNames(file, line)
+		if err == nil {
+			a = formatArgs(argNames, a...)
+		}
+
+		p := []interface{}{prefix(pc, file, line)}
+		a = append(p, a...)
 	}
 
-	argNames, err := argNames(file, line)
-	if err == nil {
-		a = formatArgs(argNames, a...)
-	}
-
-	p := []interface{}{prefix(pc, file, line)}
-	a = append(p, a...)
 	mu.Lock()
 	_, err = fmt.Fprintln(fd, a...)
 	mu.Unlock()

--- a/q.go
+++ b/q.go
@@ -1,7 +1,11 @@
 package q
 
 import (
+	"errors"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -31,6 +35,11 @@ func Println(a ...interface{}) {
 		_, err = fmt.Fprintln(fd, a...)
 		mu.Unlock()
 		return
+	}
+
+	argNames, err := argNames(file, line)
+	if err == nil {
+		a = formatArgs(argNames, a...)
 	}
 
 	p := []interface{}{prefix(pc, file, line)}
@@ -76,4 +85,68 @@ func prefix(pc uintptr, file string, line int) string {
 	callerName := runtime.FuncForPC(pc).Name()
 
 	return fmt.Sprintf("[%s %s:%d %s]", t, shortFile, line, callerName)
+}
+
+// formatArgs turns a slice of arguments into pretty-printed strings. If the
+// argument variable name is present in argNames, it will be returned as a
+// name=value string, e.g. "port=443".
+func formatArgs(argNames []string, a ...interface{}) []interface{} {
+	for i := 0; i < len(a); i++ {
+		var namePrefix string
+		if argNames[i] != "" {
+			namePrefix = argNames[i] + "="
+		}
+
+		a[i] = namePrefix + fmt.Sprintf("%#v", a[i])
+	}
+	return a
+}
+
+// argNames returns the names of all the variable arguments for the q.Print*()
+// call at the given file and line number. If the argument is not a variable,
+// the slice will contain an empty string at the index position for that
+// argument. For example, q.Print(a, 123) will result in []string{"a", ""}
+// for arg names, because 123 is not a variable name.
+func argNames(file string, line int) ([]string, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		return nil, errors.New("failed to parse source file: " + file)
+	}
+
+	var names []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		// if this is a function call on the expected line number
+		if call, is := n.(*ast.CallExpr); is && fset.Position(call.End()).Line == line {
+			if qCall(call) {
+				for _, arg := range call.Args {
+					names = append(names, argName(arg))
+				}
+			}
+		}
+		return true
+	})
+
+	return names, nil
+}
+
+// qCall returns true if the given function call expression is for a function in
+// the q package, e.g. q.Printf().
+func qCall(n *ast.CallExpr) bool {
+	if sel, is := n.Fun.(*ast.SelectorExpr); is {
+		if ident, is := sel.X.(*ast.Ident); is && ident.Name == "q" {
+			return true
+		}
+	}
+	return false
+}
+
+// argName returns the variable name of the given argument if it's a variable.
+// If the argument is something else, like a literal or a function call, argName
+// returns an empty string.
+func argName(arg ast.Expr) string {
+	if ident, is := arg.(*ast.Ident); is && ident.Obj.Kind == ast.Var {
+		return ident.Obj.Name
+	}
+	return ""
 }

--- a/q.go
+++ b/q.go
@@ -111,7 +111,8 @@ func argNames(file string, line int) ([]string, error) {
 
 	var names []string
 	ast.Inspect(f, func(n ast.Node) bool {
-		if call, is := n.(*ast.CallExpr); !is {
+		call, is := n.(*ast.CallExpr)
+		if !is {
 			return true
 		}
 

--- a/q.go
+++ b/q.go
@@ -18,6 +18,9 @@ func Println(a ...interface{}) {
 	f := filepath.Join(os.TempDir(), LogFile)
 	fd, err := os.OpenFile(f, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
+		// TODO: don't panic. people will forget and leave q.Print() calls in
+		// their code, which will end up in prod. we don't want to crash the
+		// server because we don't have permissions to write to /tmp.
 		panic(err)
 	}
 	defer fd.Close()
@@ -36,7 +39,7 @@ func Println(a ...interface{}) {
 	}
 
 	if err != nil {
-		panic(err)
+		panic(err) // TODO: don't panic
 	}
 }
 
@@ -44,7 +47,7 @@ func Printf(format string, a ...interface{}) {
 	f := filepath.Join(os.TempDir(), LogFile)
 	fd, err := os.OpenFile(f, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
-		panic(err)
+		panic(err) // TODO: don't panic
 	}
 	defer fd.Close()
 
@@ -61,7 +64,7 @@ func Printf(format string, a ...interface{}) {
 	}
 
 	if err != nil {
-		panic(err)
+		panic(err) // TODO: don't panic
 	}
 }
 

--- a/q.go
+++ b/q.go
@@ -40,6 +40,7 @@ func Println(a ...interface{}) {
 		a = append(p, a...)
 	}
 
+	a = append(a, "\n")
 	mu.Lock()
 	_, err = fmt.Fprintln(fd, a...)
 	mu.Unlock()

--- a/qq.go
+++ b/qq.go
@@ -21,7 +21,7 @@ func Println(a ...interface{}) {
 	f := filepath.Join(os.TempDir(), LogFile)
 	fd, err := os.OpenFile(f, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
-		// TODO: don't panic. people will forget and leave q.Print() calls in
+		// TODO: don't panic. people will forget and leave qq.Print() calls in
 		// their code, which will end up in prod. we don't want to crash the
 		// server because we don't have permissions to write to /tmp.
 		panic(err)
@@ -97,10 +97,10 @@ func formatArgs(names []string, values []interface{}) []interface{} {
 	return values
 }
 
-// argNames returns the names of all the variable arguments for the q.Print*()
+// argNames returns the names of all the variable arguments for the qq.Print*()
 // call at the given file and line number. If the argument is not a variable,
 // the slice will contain an empty string at the index position for that
-// argument. For example, q.Print(a, 123) will result in []string{"a", ""}
+// argument. For example, qq.Print(a, 123) will result in []string{"a", ""}
 // for arg names, because 123 is not a variable name.
 func argNames(file string, line int) ([]string, error) {
 	fset := token.NewFileSet()
@@ -120,7 +120,7 @@ func argNames(file string, line int) ([]string, error) {
 			return true
 		}
 
-		if !qCall(call) {
+		if !qqCall(call) {
 			return true
 		}
 
@@ -133,9 +133,9 @@ func argNames(file string, line int) ([]string, error) {
 	return names, nil
 }
 
-// qCall returns true if the given function call expression is for a function in
-// the q package, e.g. q.Printf().
-func qCall(n *ast.CallExpr) bool {
+// qqCall returns true if the given function call expression is for a function
+// in the qq package, e.g. qq.Printf().
+func qqCall(n *ast.CallExpr) bool {
 	sel, is := n.Fun.(*ast.SelectorExpr)
 	if !is {
 		return false
@@ -146,7 +146,7 @@ func qCall(n *ast.CallExpr) bool {
 		return false
 	}
 
-	return ident.Name == "q"
+	return ident.Name == "qq"
 }
 
 // argName returns the name of the given argument if it's a variable. If the


### PR DESCRIPTION
- `q.Println()` will now print like this:
```
[22:14:16 main.go:20 main.foo] a=123 b="hello" "hello" greeting="howdy" f=3.14 main.MyType{x:666, y:"satan"}
[22:14:16 main.go:22 main.foo] "hi" a=123 b="hello" 123 3.14159
```
`q.Printf()` is still TBD.

the eventual goal is to make it look like this:
![image](https://cloud.githubusercontent.com/assets/1250684/12710190/e08f9bea-c868-11e5-90c3-bd1b22702624.png)


- set `LogFile` (`/tmp/q.log`) once in the `init()`. `q.LogFile` now contains the full path to the log file.